### PR TITLE
fix: Switching to /opt/sd to prevent collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 2.0.0
+
+Breaking Change:
+ - Requires Launcher version 3.* due to new volume location

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ class DockerExecutor extends Executor {
             .then(launchContainer => this._createContainer({
                 name: `${config.buildId}-build`,
                 Image: config.container,
-                Entrypoint: '/opt/screwdriver/tini',
+                Entrypoint: '/opt/sd/tini',
                 Labels: {
                     sdbuild: config.buildId
                 },
@@ -154,17 +154,17 @@ class DockerExecutor extends Executor {
                     '-c',
                     [
                         // Run the launcher in the background
-                        '/opt/screwdriver/launch',
+                        '/opt/sd/launch',
                         '--api-uri',
                         this.ecosystem.api,
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         config.buildId,
                         '&',
                         // Run the logservice in the background
-                        '/opt/screwdriver/logservice',
+                        '/opt/sd/logservice',
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         '--api-uri',
                         this.ecosystem.store,
                         '--build',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-docker",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Docker Swarm Executor for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,6 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
     "jenkins-mocha": "^3.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.6",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -129,7 +129,7 @@ describe('index', () => {
             const buildArgs = {
                 name: `${buildId}-build`,
                 Image: container,
-                Entrypoint: '/opt/screwdriver/tini',
+                Entrypoint: '/opt/sd/tini',
                 Labels: {
                     sdbuild: buildId
                 },
@@ -137,16 +137,16 @@ describe('index', () => {
                     '--',
                     '/bin/sh',
                     '-c', [
-                        '/opt/screwdriver/launch',
+                        '/opt/sd/launch',
                         '--api-uri',
                         'api',
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         buildId,
                         '&',
-                        '/opt/screwdriver/logservice',
+                        '/opt/sd/logservice',
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         '--api-uri',
                         'store',
                         '--build',
@@ -218,7 +218,7 @@ describe('index', () => {
             const buildArgs = {
                 name: `${buildId}-build`,
                 Image: container,
-                Entrypoint: '/opt/screwdriver/tini',
+                Entrypoint: '/opt/sd/tini',
                 Labels: {
                     sdbuild: buildId
                 },
@@ -226,16 +226,16 @@ describe('index', () => {
                     '--',
                     '/bin/sh',
                     '-c', [
-                        '/opt/screwdriver/launch',
+                        '/opt/sd/launch',
                         '--api-uri',
                         'api',
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         buildId,
                         '&',
-                        '/opt/screwdriver/logservice',
+                        '/opt/sd/logservice',
                         '--emitter',
-                        '/opt/screwdriver/emitter',
+                        '/opt/sd/emitter',
                         '--api-uri',
                         'store',
                         '--build',


### PR DESCRIPTION
We have some legacy containers with contents in `/opt/screwdriver`.  This changes the mounted location to `/opt/sd` to prevent any namespace collisions.