### PR TITLE
fix: support container names from specific docker registries

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.1.0",
+    "docker-parse-image": "^3.0.1",
     "dockerode": "^2.3.1",
     "hoek": "^4.1.0",
     "screwdriver-executor-base": "^5.2.0"


### PR DESCRIPTION
## Context

The executor-docker assumes that users will pull images from Docker Hub. Unfortunately, this limits what images a user can use; they cannot use an image hosted on a private or personal Docker registry.

## Objective 

This fix aims to allow an image hosted on a private or personal Docker registry.

## Miscellaneous 

* Resolves screwdriver-cd/screwdriver#519
* Official repositories are implied to be part of the `library` namespace. This change also introduces a new behavior that the namespace is now made explicit within the use of this module.