### PR TITLE
Use of a private registry is broken.

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,11 +122,9 @@ class DockerExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        const { fullname } = imageParser(config.container);
-        const containerNameParts = fullname.split(':');
-
-        const buildTag = containerNameParts.pop();
-        const buildImage = containerNameParts.join(':');
+        const piecesParts = imageParser(config.container);
+        const buildTag = piecesParts.tag
+        const buildImage = piecesParts.name
 
         return Promise.all(
             [

--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@ class DockerExecutor extends Executor {
      */
     _start(config) {
         const piecesParts = imageParser(config.container);
-        const buildTag = piecesParts.tag
-        const buildImage = piecesParts.name
+        const buildTag = piecesParts.tag;
+        const buildImage = piecesParts.name;
 
         return Promise.all(
             [

--- a/index.js
+++ b/index.js
@@ -121,10 +121,32 @@ class DockerExecutor extends Executor {
      * @param  {String}   config.token      JWT for the Build
      * @return {Promise}
      */
+
     _start(config) {
         const piecesParts = imageParser(config.container);
-        const buildTag = piecesParts.tag;
-        const buildImage = piecesParts.name;
+        let buildTag = piecesParts.tag;
+        let buildImage = piecesParts.name;
+
+        /**
+         *
+         * the docker-parse-image returns a fullname that always contains
+         * a namespace, which defaults to 'library' if no namespace is specified.
+         * perhaps library is the historical place to put things? but,
+         * my private registry does not work with 'library' injected in to the
+         * docker image name.  In other words, if I try to parse:
+         * 'myregistry.private.com/myimage'
+         * i end up with
+         * 'myregistry.private.com/library/myimage:latest'
+         * there is no library namespace in my private registry, so this fails.
+         */
+        if (piecesParts.tag !== null && piecesParts.tag !== 'latest') {
+            const containerNameParts = piecesParts.name.split(':');
+
+            containerNameParts.pop();
+            buildImage = containerNameParts.join(':');
+        } else {
+            buildTag = 'latest';
+        }
 
         return Promise.all(
             [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -181,7 +181,7 @@ describe('index', function () {
 
         it('creates the required containers and starts them', () => {
             const buildImageArgs = {
-                fromImage: 'library/node',
+                fromImage: 'node',
                 tag: '6'
             };
 
@@ -207,7 +207,7 @@ describe('index', function () {
         it('supports prefixed containers', () => {
             const prefix = 'beta_';
             const buildImageArgs = {
-                fromImage: 'library/node',
+                fromImage: 'node',
                 tag: '6'
             };
 
@@ -292,7 +292,7 @@ describe('index', function () {
 
         it('creates containers without specifying a tag', () => {
             const buildImageArgs = {
-                fromImage: 'library/node',
+                fromImage: 'node',
                 tag: 'latest'
             };
 
@@ -320,7 +320,7 @@ describe('index', function () {
 
         it('creates containers from a private docker registry and starts them', () => {
             const buildImageArgs = {
-                fromImage: 'docker-registry.foo.bar:1111/library/someImage',
+                fromImage: 'docker-registry.foo.bar:1111/someImage',
                 tag: 'latest'
             };
 
@@ -348,7 +348,7 @@ describe('index', function () {
 
         it('creates containers from a private docker registry without specifying a tag', () => {
             const buildImageArgs = {
-                fromImage: 'docker-registry.foo.bar:1111/library/someImage',
+                fromImage: 'docker-registry.foo.bar:1111/someImage',
                 tag: 'latest'
             };
 


### PR DESCRIPTION
a reference of `mydomain:port/myimage:tag` was being changed to
`mydomain:port/library/myimage:tag`, which is not found in a private registry.
I removed library from the resulting image name. Here is a discussion about a similar issue: [openshift/origin](https://github.com/openshift/origin/issues/6570). 