### PR TITLE
fix: update README to remove swarm references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > Docker Executor for Screwdriver
 
-This is an executor for the Screwdriver CD solution that interacts with Docker (local and swarm).
+This is an executor for the Screwdriver CD solution that interacts with Docker (local and remote).
 
 ## Usage
 
@@ -13,7 +13,7 @@ npm install screwdriver-executor-docker
 
 ### Initialization
 
-The class has a variety of knobs to tweak when interacting with your Swarm instance.
+The class has a variety of knobs to tweak when interacting with Docker.
 
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|


### PR DESCRIPTION
## Context

Docker swarm is not supported with this executor. In swarm mode we need to create one shot services not containers, which requires further code changes.

We will have to implement the equivalent of the following steps when running in swarm mode

```
docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=SWARM_MASTER_HOST:2376 service create --restart-condition none --name helloworld -d alpine ls
docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=SWARM_MASTER_HOST:2376 service logs helloworld
docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=SWARM_MASTER_HOST2376 service ps helloworld # Wait until it's completed
docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=SWARM_MASTER_HOST2376 service rm helloworld
```

Dockerode does support Docker swarm https://github.com/apocas/dockerode/blob/3d0df1bf0160777d2c7bc9efc37aab12fe53b6af/test/swarm.js#L136
