### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.6",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`