### PR TITLE
fix(1030): [2] Add to call method in executor-base to get JWT for build

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,8 @@ class DockerExecutor extends Executor {
 
         return Promise.all(
             [
+                // exchange temporal JWT to build JWT
+                this.exchangeTokenForBuild(config),
                 this._createImage({
                     fromImage: 'screwdrivercd/launcher',
                     tag: this.launchVersion

--- a/index.js
+++ b/index.js
@@ -161,14 +161,18 @@ class DockerExecutor extends Executor {
                     tag: buildTag
                 })
             ])
-            .then(() => this._createContainer({
-                name: `${this.prefix}${config.buildId}-init`,
-                Image: `screwdrivercd/launcher:${this.launchVersion}`,
-                Entrypoint: '/bin/true',
-                Labels: {
-                    sdbuild: `${this.prefix}${config.buildId}`
-                }
-            }))
+            .then((results) => {
+                config.token = results[0];
+
+                return this._createContainer({
+                    name: `${this.prefix}${config.buildId}-init`,
+                    Image: `screwdrivercd/launcher:${this.launchVersion}`,
+                    Entrypoint: '/bin/true',
+                    Labels: {
+                        sdbuild: `${this.prefix}${config.buildId}`
+                    }
+                });
+            })
             .then(launchContainer => this._createContainer({
                 name: `${this.prefix}${config.buildId}-build`,
                 Image: config.container,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,7 +105,7 @@ describe('index', function () {
     describe('start', () => {
         const buildId = 1992;
         const apiUri = 'https://api.sd.cd';
-        let token = '123456';
+        const token = '123456';
         let container = 'node:6';
         const launcherImageArgs = {
             fromImage: 'screwdrivercd/launcher',
@@ -119,7 +119,8 @@ describe('index', function () {
 
         beforeEach(() => {
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves(token = '7890123');
+            exchangeTokenStub.resolves();
+
             launcherContainer = {
                 id: 'launcherID',
                 start: sinon.stub().yieldsAsync(new Error()),
@@ -204,7 +205,6 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
-                assert.equal(token, '7890123');
             });
         });
 
@@ -282,7 +282,7 @@ describe('index', function () {
             });
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves(token = '7890123');
+            exchangeTokenStub.resolves();
 
             return executor.start({
                 buildId, container, apiUri, token
@@ -294,7 +294,6 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
-                assert.equal(token, '7890123');
             });
         });
 
@@ -323,7 +322,6 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
-                assert.equal(token, '7890123');
             });
         });
 
@@ -352,7 +350,6 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
-                assert.equal(token, '7890123');
             });
         });
 
@@ -381,7 +378,6 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
-                assert.equal(token, '7890123');
             });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,7 +105,7 @@ describe('index', function () {
     describe('start', () => {
         const buildId = 1992;
         const apiUri = 'https://api.sd.cd';
-        const token = '123456';
+        let token = '123456';
         let container = 'node:6';
         const launcherImageArgs = {
             fromImage: 'screwdrivercd/launcher',
@@ -115,8 +115,11 @@ describe('index', function () {
         let launcherContainer;
         let launcherArgs;
         let buildContainer;
+        let exchangeTokenStub;
 
         beforeEach(() => {
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves(token = '7890123');
             launcherContainer = {
                 id: 'launcherID',
                 start: sinon.stub().yieldsAsync(new Error()),
@@ -201,6 +204,7 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
+                assert.equal(token, '7890123');
             });
         });
 
@@ -277,6 +281,9 @@ describe('index', function () {
                 }
             });
 
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves(token = '7890123');
+
             return executor.start({
                 buildId, container, apiUri, token
             }).then(() => {
@@ -287,6 +294,7 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
+                assert.equal(token, '7890123');
             });
         });
 
@@ -315,6 +323,7 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
+                assert.equal(token, '7890123');
             });
         });
 
@@ -343,6 +352,7 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
+                assert.equal(token, '7890123');
             });
         });
 
@@ -371,6 +381,7 @@ describe('index', function () {
                 assert.calledWith(dockerMock.createContainer, launcherArgs);
                 assert.callCount(dockerMock.createContainer, 2);
                 assert.callCount(buildContainer.start, 1);
+                assert.equal(token, '7890123');
             });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,7 +119,7 @@ describe('index', function () {
 
         beforeEach(() => {
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
 
             launcherContainer = {
                 id: 'launcherID',
@@ -171,7 +171,7 @@ describe('index', function () {
                     ].join(' ')
                 ],
                 Env: [
-                    `SD_TOKEN=${token}`
+                    'SD_TOKEN=someBuildToken'
                 ],
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
@@ -255,7 +255,7 @@ describe('index', function () {
                     ].join(' ')
                 ],
                 Env: [
-                    `SD_TOKEN=${token}`
+                    'SD_TOKEN=someBuildToken'
                 ],
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
@@ -282,7 +282,7 @@ describe('index', function () {
             });
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
 
             return executor.start({
                 buildId, container, apiUri, token


### PR DESCRIPTION
## Objective 
- When build starts in executor, call [`exchangeTokenForBuild()`](https://github.com/screwdriver-cd/executor-base/pull/42) method which is added in `executor-base` to get build JWT, and replace `config.token` to the new JWT.

## References
- Issues: 
　https://github.com/screwdriver-cd/screwdriver/issues/998
　https://github.com/screwdriver-cd/screwdriver/issues/1030
　https://github.com/screwdriver-cd/screwdriver/issues/1075
- Related: (other PRs)
　https://github.com/screwdriver-cd/screwdriver/pull/1087
　https://github.com/screwdriver-cd/models/pull/245
　https://github.com/screwdriver-cd/executor-base/pull/42
　https://github.com/screwdriver-cd/executor-k8s/pull/84
　https://github.com/screwdriver-cd/executor-k8s-vm/pull/33
　https://github.com/screwdriver-cd/executor-docker/pull/25
　https://github.com/screwdriver-cd/executor-jenkins/pull/20

## TODO
- [x] Add unit test