### PR TITLE
feat(1167): [2][small] remove calling exchangeTokenForBuild method

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,8 +150,6 @@ class DockerExecutor extends Executor {
 
         return Promise.all(
             [
-                // exchange temporal JWT to build JWT
-                this.exchangeTokenForBuild(config),
                 this._createImage({
                     fromImage: 'screwdrivercd/launcher',
                     tag: this.launchVersion
@@ -161,18 +159,14 @@ class DockerExecutor extends Executor {
                     tag: buildTag
                 })
             ])
-            .then((results) => {
-                config.token = results[0];
-
-                return this._createContainer({
-                    name: `${this.prefix}${config.buildId}-init`,
-                    Image: `screwdrivercd/launcher:${this.launchVersion}`,
-                    Entrypoint: '/bin/true',
-                    Labels: {
-                        sdbuild: `${this.prefix}${config.buildId}`
-                    }
-                });
-            })
+            .then(() => this._createContainer({
+                name: `${this.prefix}${config.buildId}-init`,
+                Image: `screwdrivercd/launcher:${this.launchVersion}`,
+                Entrypoint: '/bin/true',
+                Labels: {
+                    sdbuild: `${this.prefix}${config.buildId}`
+                }
+            }))
             .then(launchContainer => this._createContainer({
                 name: `${this.prefix}${config.buildId}-build`,
                 Image: config.container,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -115,12 +115,8 @@ describe('index', function () {
         let launcherContainer;
         let launcherArgs;
         let buildContainer;
-        let exchangeTokenStub;
 
         beforeEach(() => {
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
-
             launcherContainer = {
                 id: 'launcherID',
                 start: sinon.stub().yieldsAsync(new Error()),
@@ -173,7 +169,7 @@ describe('index', function () {
                     ].join(' ')
                 ],
                 Env: [
-                    'SD_TOKEN=someBuildToken'
+                    `SD_TOKEN=${token}`
                 ],
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
@@ -259,7 +255,7 @@ describe('index', function () {
                     ].join(' ')
                 ],
                 Env: [
-                    'SD_TOKEN=someBuildToken'
+                    `SD_TOKEN=${token}`
                 ],
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
@@ -284,9 +280,6 @@ describe('index', function () {
                     store: 'store'
                 }
             });
-
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
 
             return executor.start({
                 buildId, container, apiUri, token


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For issue https://github.com/screwdriver-cd/screwdriver/issues/1167 , we should exchange temporary JWT token in launcher, not in executor-*.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I removed calling exchangeTokenForBuild method form executor-docker.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
related PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/201
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/88
executor-k8s-vm: https://github.com/screwdriver-cd/executor-k8s-vm/pull/35
executor-jenkins: https://github.com/screwdriver-cd/executor-jenkins/pull/23