### PR TITLE
fix(1839): Pass timeout value from build config to container

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,9 @@ class DockerExecutor extends Executor {
         const piecesParts = imageParser(config.container);
         let buildTag = piecesParts.tag;
         let buildImage = piecesParts.name;
+        const buildTimeout = hoek.reach(config, 'annotations>screwdriver.cd/timeout',
+            { separator: '>' });
+        const timeout = parseInt(buildTimeout || DEFAULT_BUILD_TIMEOUT, 10);
 
         /**
          *
@@ -184,7 +187,7 @@ class DockerExecutor extends Executor {
                         `"${config.token}"`,
                         this.ecosystem.api,
                         this.ecosystem.store,
-                        DEFAULT_BUILD_TIMEOUT,
+                        timeout,
                         config.buildId,
                         this.ecosystem.ui
                     ].join(' ')


### PR DESCRIPTION
## Context

The timeout annotations set by user for a job is not being passed to the container currently and it uses the default timeout.

## Objective

This PR will parse the annotations for timeout value or use default timeout and pass to the container for timeout to work correctly

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
