### PR TITLE
fix: timeout for beaker was not getting applied locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,15 @@ class DockerExecutor extends Executor {
         this.docker = new Docker(options.docker);
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';
-        this.breaker = new Fusebox((obj, cb) => obj.func(cb), hoek.applyToDefaults({
+
+        const breakerOptions = hoek.applyToDefaults({
             breaker: {
-                timeout: 5 * 60 * 1000 // Default to 5 minute timeout
+                maxFailures: 10,
+                timeout: 5 * 60 * 1000 // Default to 5 minute timeout,
             }
-        }, options.fusebox));
+        }, options.fusebox || {});
+
+        this.breaker = new Fusebox((obj, cb) => obj.func(cb), breakerOptions);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -39,8 +39,9 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^7.0.0",
+    "mocha": "^7.0.1",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "sinon": "^7.1.0"
   },
   "dependencies": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

When developing locally builds frequently fail to run because of errors like these.

```
Getting errors with [{}]: Error: (HTTP code 409) unexpected - Conflict. The container name "/74-init" is already in use by container "5466961e980f206e95f7db9602aa502327a6c1c4199e32de2c6dbe2a955b875d". You have to remove (or rename) that container to be able to reuse that name.

```

This happens because `createContainer` https://github.com/screwdriver-cd/executor-docker/blob/master/index.js#L55-L59 times out and since we are using the same container name again, Docker will report failure. Randomizing name is a different issue to fix, but issue here is the timeout setting for breaker not working because the `hoek` function is returning `null` here - https://github.com/screwdriver-cd/executor-docker/blob/master/index.js#L42


## Objective

Make timeout setting in `executor-docker` work - https://github.com/screwdriver-cd/executor-docker/blob/master/index.js#L44
Actual fix is this `options.fusebox || {}`

## References

1. https://github.com/screwdriver-cd/executor-docker/blob/master/index.js#L44

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
