### PR TITLE
Support running Docker inside Docker Executor

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,9 @@ class DockerExecutor extends Executor {
                         Memory: 2 * 1024 * 1024 * 1024,
                         // 3 GB of memory + swap (aka, 1 GB of swap)
                         MemoryLimit: 3 * 1024 * 1024 * 1024,
-                        VolumesFrom: [`${launchContainer.id}:rw`]
+                        VolumesFrom: [`${launchContainer.id}:rw`],
+                        Privileged: true,
+                        Binds: ['/var/run/docker.sock:/var/run/docker.sock']
                     }
                 })
             )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -144,7 +144,9 @@ describe('index', function () {
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
                     MemoryLimit: 3 * 1024 * 1024 * 1024,
-                    VolumesFrom: ['launcherID:rw']
+                    VolumesFrom: ['launcherID:rw'],
+                    Privileged: true,
+                    Binds: ['/var/run/docker.sock:/var/run/docker.sock']
                 }
             };
         });
@@ -236,7 +238,9 @@ describe('index', function () {
                 HostConfig: {
                     Memory: 2 * 1024 * 1024 * 1024,
                     MemoryLimit: 3 * 1024 * 1024 * 1024,
-                    VolumesFrom: ['launcherID:rw']
+                    VolumesFrom: ['launcherID:rw'],
+                    Privileged: true,
+                    Binds: ['/var/run/docker.sock:/var/run/docker.sock']
                 }
             };
 


### PR DESCRIPTION
## Context

Hi SD team, we open this PR because we had the following error when we were running Docker inside executor-docker:

```bash
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Our screwdriver.yaml file looks like this (simplified for demo purpose):

```yaml
jobs:
  main:
    requires: [~pr, ~commit]
    image: buildpack-deps:22.04-scm
    steps:
      - install-docker: curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
      - spin-up-container: docker run hello-world
```

## Objective

We would like to bind mount `/var/run/docker.sock` onto the docker executor container so that our inner Docker (`hello-world`) can access the host Docker daemon and spins up inner Docker successfully

> We tried screwdriver [config file](https://github.com/screwdriver-cd/screwdriver/tree/master/config) approach but looks like [the config option didn't get passed into `HostConfig` container API call via dockerode](https://github.com/screwdriver-cd/executor-docker/blob/master/index.js#L206-L211); so we decided to modify executor-docker in this PR

Thanks 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
