### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-docker",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Docker Swarm Executor for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -47,6 +47,6 @@
     "circuit-fuses": "^5.0.0",
     "docker-parse-image": "^3.0.1",
     "dockerode": "^3.3.4",
-    "screwdriver-executor-base": "^9.0.0"
+    "screwdriver-executor-base": "^10.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

feat(3171): Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
