### PR TITLE
fix(3465): Change Entrypoint to array format in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ class DockerExecutor extends Executor {
                 this._createContainer({
                     name: `${this.prefix}${config.buildId}-init`,
                     Image: `${this.launchImage}:${this.launchVersion}`,
-                    Entrypoint: '/bin/true',
+                    Entrypoint: ['/bin/true'],
                     Labels: {
                         sdbuild: `${this.prefix}${config.buildId}`
                     }
@@ -187,7 +187,7 @@ class DockerExecutor extends Executor {
                 this._createContainer({
                     name: `${this.prefix}${config.buildId}-build`,
                     Image: config.container,
-                    Entrypoint: '/opt/sd/launcher_entrypoint.sh',
+                    Entrypoint: ['/opt/sd/launcher_entrypoint.sh'],
                     Labels: {
                         sdbuild: `${this.prefix}${config.buildId}`
                     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -123,7 +123,7 @@ describe('index', function () {
             launcherArgs = {
                 name: `${buildId}-init`,
                 Image: 'screwdrivercd/launcher:stable',
-                Entrypoint: '/bin/true',
+                Entrypoint: ['/bin/true'],
                 Labels: {
                     sdbuild: buildId.toString()
                 }
@@ -136,7 +136,7 @@ describe('index', function () {
             buildArgs = {
                 name: `${buildId}-build`,
                 Image: container,
-                Entrypoint: '/opt/sd/launcher_entrypoint.sh',
+                Entrypoint: ['/opt/sd/launcher_entrypoint.sh'],
                 Labels: {
                     sdbuild: buildId.toString()
                 },
@@ -222,7 +222,7 @@ describe('index', function () {
             launcherArgs = {
                 name: `${prefix}${buildId}-init`,
                 Image: 'screwdrivercd/launcher:stable',
-                Entrypoint: '/bin/true',
+                Entrypoint: ['/bin/true'],
                 Labels: {
                     sdbuild: `${prefix}${buildId}`
                 }
@@ -230,7 +230,7 @@ describe('index', function () {
             buildArgs = {
                 name: `${prefix}${buildId}-build`,
                 Image: container,
-                Entrypoint: '/opt/sd/launcher_entrypoint.sh',
+                Entrypoint: ['/opt/sd/launcher_entrypoint.sh'],
                 Labels: {
                     sdbuild: `${prefix}${buildId}`
                 },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Recently, container creation started failing with the following error:

```
err in start job: Error: (HTTP code 400) bad parameter - invalid JSON: json: cannot unmarshal string into Go struct field CreateRequest.Config.Entrypoint of type []string
```

This appears to be caused by stricter validation in newer Docker Engine versions, where Entrypoint is strictly expected to be an array of strings (`[]string`) instead of a single string.

Previously, passing a string value (e.g., '/bin/true') worked without errors, but this is no longer accepted.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR updates the Entrypoint parameter from a string to an array format:

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

issue - https://github.com/screwdriver-cd/screwdriver/issues/3465

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
